### PR TITLE
Prevent users on Windows from seeing an "UnboundLocalError"

### DIFF
--- a/ffmpeg_quality_metrics/__main__.py
+++ b/ffmpeg_quality_metrics/__main__.py
@@ -372,9 +372,10 @@ def main():
         if not cli_args.model_path:
             if IS_WIN:
                 print_stderr(
-                    "Cannot not automatically determine VMAF model path under Windows."
+                    "Cannot not automatically determine VMAF model path under Windows. "
                     "Please specify the --model-path manually."
                 )
+                sys.exit(1)
             else:
                 if has_brew():
                     model_path = os.path.join(
@@ -386,7 +387,7 @@ def main():
                         "Please specify the --model-path manually or install ffmpeg with Homebrew."
                     )
                     sys.exit(1)
-        else:
+        else: # The model path was specified manually.
             model_path = cli_args.model_path
         if not os.path.isfile(model_path):
             print_stderr(


### PR DESCRIPTION
Added `sys.exit(1)` to prevent users on Windows from seeing `UnboundLocalError: local variable 'model_path' referenced before assignment` when they do not specify a model path manually.

Also added a space after the full stop on line 375.