### PR TITLE
Add option to set the value of libvmaf's n_threads option, deprecate .pkl model files

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,9 @@ optional arguments:
 
 Use the `-m/--model-path` option to set the path to the model file.
 
-For example, if you have the model files saved at:
+For example, if you have the model file saved at:
 
 ```
-/usr/local/opt/libvmaf/share/model/vmaf_v0.6.1.json
 /usr/local/opt/libvmaf/share/model/vmaf_v0.6.1.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,20 +27,11 @@ Contents:
 
 - Python 3.6 or higher
 - FFmpeg:
-    - download a static build from [their website](http://ffmpeg.org/download.html))
-    - put the `ffmpeg` executable in your `$PATH`
+    - **Linux:** Download the git master build from [here](https://johnvansickle.com/ffmpeg/). Installation instructions, as well as how to add FFmpeg and FFprobe to your PATH, can be found [here](https://www.johnvansickle.com/ffmpeg/faq/).
+    - **macOS:** Download the *snapshot* build from [here](https://evermeet.cx/ffmpeg/).
+    - **Windows:** Download an FFmpeg binary from [here](https://www.gyan.dev/ffmpeg/builds/). The `git essentials` build will suffice. 
 
-Optionally, you may install FFmpeg with `libvmaf` support to run VMAF score calculation. Under Linux and macOS, this can be done with the following steps:
-
-```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-brew tap homebrew-ffmpeg/ffmpeg
-brew install homebrew-ffmpeg/ffmpeg/ffmpeg --with-libvmaf
-```
-
-This may take a while.
-
-Under Windows, you have to install ffmpeg and VMAF manually, or using [helper scripts](https://github.com/rdp/ffmpeg-windows-build-helpers).
+Put the `ffmpeg` executable in your `$PATH`.
 
 ## Installation
 
@@ -63,10 +54,12 @@ The distorted file will be automatically scaled to the resolution of the referen
 See `ffmpeg_quality_metrics -h`:
 
 ```
-usage:  [-h] [-n] [-v] [-ev] [-m MODEL_PATH] [-p] [-dp]
-        [-s {fast_bilinear,bilinear,bicubic,experimental,neighbor,area,bicublin,gauss,sinc,lanczos,spline}]
-        [-of {json,csv}] [-r FRAMERATE] [-t THREADS]
-        dist ref
+usage: __main__.py [-h] [-n] [-v] [-ev] [-m MODEL_PATH] [-p] [-dp]
+                   [-s {fast_bilinear,bilinear,bicubic,experimental,neighbor,area,bicublin,gauss,sinc,lanczos,spline}]
+                   [-of {json,csv}] [-r FRAMERATE] [-t THREADS] [-nt N_THREADS]
+                   dist ref
+
+ffmpeg_quality_metrics v0.8.0
 
 positional arguments:
   dist                  input file, distorted
@@ -74,45 +67,41 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  -n, --dry-run         Do not run command, just show what would be done
-                        (default: False)
+  -n, --dry-run         Do not run command, just show what would be done (default: False)
   -v, --verbose         Show verbose output (default: False)
-  -ev, --enable-vmaf    Enable VMAF computation; calculates VMAF as well as
-                        SSIM and PSNR (default: False)
+  -ev, --enable-vmaf    Enable VMAF computation; calculates VMAF as well as SSIM and PSNR (default: False)
   -m MODEL_PATH, --model-path MODEL_PATH
-                        Set path to VMAF model file (.pkl) (default: None)
+                        Specify the path of the VMAF model file (default: None)
   -p, --phone-model     Enable VMAF phone model (default: False)
   -dp, --disable-psnr-ssim
-                        Disable PSNR/SSIM computation. Use VMAF to get YUV
-                        estimate. (default: False)
+                        Disable PSNR/SSIM computation. Use VMAF to get YUV estimate. (default: False)
   -s {fast_bilinear,bilinear,bicubic,experimental,neighbor,area,bicublin,gauss,sinc,lanczos,spline}, --scaling-algorithm {fast_bilinear,bilinear,bicubic,experimental,neighbor,area,bicublin,gauss,sinc,lanczos,spline}
                         Scaling algorithm for ffmpeg (default: bicubic)
   -of {json,csv}, --output-format {json,csv}
-                        output in which format (default: json)
+                        Output format for the metrics (default: json)
   -r FRAMERATE, --framerate FRAMERATE
-                        force an input framerate (default: None)
+                        Force an input framerate (default: None)
   -t THREADS, --threads THREADS
                         Number of threads to do the calculations (default: 0)
-
+  -nt N_THREADS, --n-threads N_THREADS
+                        Set the value of libvmaf's n_threads option. This determines the number of threads that are used for VMAF calculation
 ```
 
 ### Specifying VMAF Model
 
-If you are running Windows, or if you want to specify a different VMAF model file than the default, you need both a `.pkl` and a `.pkl.model` file in the same path for VMAF to be able to load the model.
-
-Use the `-m/--model-path` option to set the path to the model file, by pointing it to the `.pkl` file (not the `.pkl.model` file!).
+Use the `-m/--model-path` option to set the path to the model file.
 
 For example, if you have the model files saved at:
 
 ```
-/usr/local/opt/libvmaf/share/model/vmaf_v0.6.1.pkl
-/usr/local/opt/libvmaf/share/model/vmaf_v0.6.1.pkl.model
+/usr/local/opt/libvmaf/share/model/vmaf_v0.6.1.json
+/usr/local/opt/libvmaf/share/model/vmaf_v0.6.1.json
 ```
 
 Run the command with:
 
 ```
-ffmpeg_quality_metrics dist.mkv ref.mkv -m /usr/local/opt/libvmaf/share/model/vmaf_v0.6.1.pkl
+ffmpeg_quality_metrics dist.mkv ref.mkv -m /usr/local/opt/libvmaf/share/model/vmaf_v0.6.1.json
 ```
 
 ## Running with Docker

--- a/README.md
+++ b/README.md
@@ -58,9 +58,7 @@ usage: __main__.py [-h] [-n] [-v] [-ev] [-m MODEL_PATH] [-p] [-dp]
                    [-s {fast_bilinear,bilinear,bicubic,experimental,neighbor,area,bicublin,gauss,sinc,lanczos,spline}]
                    [-of {json,csv}] [-r FRAMERATE] [-t THREADS] [-nt N_THREADS]
                    dist ref
-
-ffmpeg_quality_metrics v0.8.0
-
+                   
 positional arguments:
   dist                  input file, distorted
   ref                   input file, reference

--- a/ffmpeg_quality_metrics/__main__.py
+++ b/ffmpeg_quality_metrics/__main__.py
@@ -137,6 +137,7 @@ def calc_vmaf(
     dry_run=False,
     verbose=False,
     threads=0,
+    n_threads=str(os.cpu_count())
 ):
     vmaf_data = []
 
@@ -164,6 +165,7 @@ def calc_vmaf(
             "psnr": "1",
             "ssim": "1",
             "ms_ssim": "1",
+            "n_threads": n_threads
         }
 
         vmaf_opts_string = ":".join(f"{k}={v}" for k, v in vmaf_opts.items())
@@ -353,7 +355,7 @@ def main():
         action="store_true",
         help="Enable VMAF computation; calculates VMAF as well as SSIM and PSNR",
     )
-    parser.add_argument("-m", "--model-path", help="Set path to VMAF model file (.pkl)")
+    parser.add_argument("-m", "--model-path", help="Set path to VMAF model file")
     parser.add_argument(
         "-p", "--phone-model", action="store_true", help="Enable VMAF phone model"
     )
@@ -378,10 +380,10 @@ def main():
         type=str,
         default="json",
         choices=["json", "csv"],
-        help="output in which format",
+        help="Output format for the metrics (default: json)",
     )
     parser.add_argument(
-        "-r", "--framerate", type=float, help="force an input framerate",
+        "-r", "--framerate", type=float, help="Force an input framerate",
     )
 
     parser.add_argument(
@@ -391,7 +393,15 @@ def main():
         default=0,
         help="Number of threads to do the calculations",
     )
-   
+
+    parser.add_argument(
+        "-nt",
+        "--n-threads",
+        type=str,
+        default=os.cpu_count(),
+        help="Set the value of libvmaf\'s n_threads option. "
+             "This determines the number of threads that are used for VMAF calculation"
+    )
 
     cli_args = parser.parse_args()
 
@@ -434,6 +444,7 @@ def main():
             cli_args.dry_run,
             cli_args.verbose,
             cli_args.threads,
+            cli_args.n_threads
         )
 
     if not cli_args.disable_psnr_ssim:

--- a/ffmpeg_quality_metrics/__main__.py
+++ b/ffmpeg_quality_metrics/__main__.py
@@ -380,7 +380,7 @@ def main():
         type=str,
         default="json",
         choices=["json", "csv"],
-        help="Output format for the metrics (default: json)",
+        help="Output format for the metrics",
     )
     parser.add_argument(
         "-r", "--framerate", type=float, help="Force an input framerate",


### PR DESCRIPTION
The main changes are as follows:

- I have added the option of setting the value of libvmaf's `n_threads` option.
    - Since libvmaf v2.0.0, only 1 thread is used for VMAF calculation by default. See [this](https://github.com/Netflix/vmaf/issues/770#issuecomment-746895494). This means that, by default, VMAF calculation is not as fast as it can be for those with multi-core CPUs.

        Therefore, I have set the default value of `n_threads` to what Python's `os.cpu_count()` method returns. But users can set a different value by using the `-nt`/`--n-threads` argument.

- I have edited the README to replace `vmaf_v0.6.1.pkl` with `vmaf_v0.6.1.json` as .pkl model files have been deprecated since libvmaf v2.0.0. I have also added links to FFmpeg binaries (for Linux, macOS and Windows) that use libvmaf >v2.0.0.
These changes to the README fulfil the following goals in Issue #19:
    - > Update builds to include libvmaf 2.0 (depends on Homebrew and ffmpeg inclusion)

    - > Deprecate usage of libvmaf < 2.0