### PR TITLE
Added quit for FfmpegProgress to let it react on SIGTERM

### DIFF
--- a/ffmpeg_quality_metrics/ffmpeg_quality_metrics.py
+++ b/ffmpeg_quality_metrics/ffmpeg_quality_metrics.py
@@ -657,9 +657,13 @@ class FfmpegQualityMetrics:
         if self.progress:
             logger.debug(quoted_cmd(cmd))
             ff = FfmpegProgress(cmd, self.dry_run)
-            with tqdm(total=100, position=1, desc=desc) as pbar:
-                for progress in ff.run_command_with_progress():
-                    pbar.update(progress - pbar.n)
+            try:
+                with tqdm(total=100, position=1, desc=desc) as pbar:
+                    for progress in ff.run_command_with_progress():
+                        pbar.update(progress - pbar.n)
+            finally:
+                if ff.process.poll() is None:
+                    ff.quit()
             return ff.stderr
         else:
             _, stderr = run_command(cmd, dry_run=self.dry_run)


### PR DESCRIPTION
While using `ffmpeg-quality-metrics` API with my script, I've noticed that `ffmpeg` continues to run and allocate CPU resources even after I cancelled my script via Ctrl+C (SIGTERM signal). It's not the issue with `ffmpeg-quality-metrics` but rather it's with `ffmpeg-progress-yield` used to show the progress. So here is a little trick to make `ffmpeg-progress-yield` react and quit `ffmpeg` process when the main program exits or got canceled or killed. 

Using `ffmpeg-quality-metrics` in my code is very simple:

```py
ffqm = FfmpegQualityMetrics(str(src_path), str(dest_path), threads=threads, progress=True)
metrics = ffqm.calculate(['vmaf', 'ssim'], vmaf_options={'model_path': 'vmaf_4k_v0.6.1.json', 'n_threads': threads})
stats = ffqm.get_global_stats()
```

PS: Thank you very much for a nice library! I appreciate it very much.