### PR TITLE
Fix crash on Python 3.13 due to pstdev type check

### DIFF
--- a/ffmpeg_quality_metrics/ffmpeg_quality_metrics.py
+++ b/ffmpeg_quality_metrics/ffmpeg_quality_metrics.py
@@ -756,7 +756,7 @@ class FfmpegQualityMetrics:
                 stats[submetric_key] = {
                     "average": round(float(mean(values)), 3),
                     "median": round(float(median(values)), 3),
-                    "stdev": round(float(pstdev(values)), 3),
+                    "stdev": round(float(pstdev([float(v) for v in values])), 3),
                     "min": round(min(values), 3),
                     "max": round(max(values), 3),
                 }


### PR DESCRIPTION
Fix pstdev usage for Python 3.13 compatibility

Ensure we always pass a list of floats to statistics.pstdev to avoid AttributeError when elements are already floats.