### PR TITLE
Fix: prevent pstdev crash on non-finite values (Python 3.13)

### DIFF
--- a/ffmpeg_quality_metrics/ffmpeg_quality_metrics.py
+++ b/ffmpeg_quality_metrics/ffmpeg_quality_metrics.py
@@ -756,7 +756,7 @@ class FfmpegQualityMetrics:
                 stats[submetric_key] = {
                     "average": round(float(mean(values)), 3),
                     "median": round(float(median(values)), 3),
-                    "stdev": round(float(pstdev(values)), 3),
+                    "stdev": round(float(pstdev([float(v) for v in values])), 3),
                     "min": round(min(values), 3),
                     "max": round(max(values), 3),
                 }

--- a/ffmpeg_quality_metrics/ffmpeg_quality_metrics.py
+++ b/ffmpeg_quality_metrics/ffmpeg_quality_metrics.py
@@ -753,10 +753,11 @@ class FfmpegQualityMetrics:
             stats: Dict[str, GlobalStatsData] = {}
             for submetric_key in submetric_keys:
                 values = [float(frame[submetric_key]) for frame in metric_data]
+                finite = [float(v) for v in values if str(v) not in {"inf", "-inf", "nan"}]
                 stats[submetric_key] = {
                     "average": round(float(mean(values)), 3),
                     "median": round(float(median(values)), 3),
-                    "stdev": round(float(pstdev([float(v) for v in values])), 3),
+                    "stdev": round(float(pstdev(finite)) if len(finite) > 1 else 0.0, 3),
                     "min": round(min(values), 3),
                     "max": round(max(values), 3),
                 }


### PR DESCRIPTION
When calculating global statistics, statistics.pstdev can receive inf or NaN, causing
Attribute Error: 'float' object has no attribute 'numerator' on Python 3.13.
Filter out non-finite values before computing the standard deviation and fall back to 0.0 when fewer than two valid samples remain.