### PR TITLE
Fix `dist-delay` alignment and bound VMAF overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,21 @@ ffmpeg-quality-metrics distorted.mp4 reference.y4m
 
 The distorted file will be automatically scaled to the resolution of the reference, and the default metrics (PSNR, SSIM) will be computed.
 
-Note that if your distorted file is not in time sync with the reference, you can use the `--dist-delay` option to delay the distorted file by a certain amount of seconds (positive or negative).
+If your distorted file is not in time sync with the reference, use
+`--dist-delay` to trim the unmatched lead-in before comparison. A positive
+value means the distorted file starts that many seconds later than the
+reference, so the reference lead-in is trimmed. A negative value means the
+distorted file starts earlier, so its lead-in is trimmed:
+
+```bash
+# distorted.mp4 begins with reference content from 12.5 seconds onward
+ffmpeg-quality-metrics distorted.mp4 reference.mp4 \
+  --metrics vmaf --dist-delay 12.5
+```
+
+The files are decoded and trimmed in the filtergraph; neither input is
+re-encoded. Metrics stop at the end of the shorter aligned stream, so trailing
+content from the longer file is not compared against a repeated final frame.
 
 > [!NOTE]
 > Raw YUV files cannot be read with this tool. We should all be using lossless containers like Y4M or FFV1. If you have a raw YUV file, you can use FFmpeg to convert it to a format that this tool can read. Adjust the options as needed.
@@ -173,8 +187,9 @@ FFmpeg options:
   -s, --scaling-algorithm {fast_bilinear,bilinear,bicubic,experimental,neighbor,area,bicublin,gauss,sinc,lanczos,spline}
                                         Scaling algorithm for ffmpeg (default: bicubic)
   -r, --framerate FRAMERATE             Force an input framerate (default: None)
-  --dist-delay DIST_DELAY               Delay the distorted video against the reference by this many
-                                        seconds (default: 0.0)
+  --dist-delay DIST_DELAY               Temporally align the inputs by trimming unmatched leading
+                                        frames. Positive trims the reference; negative trims the
+                                        distorted input. (default: 0.0)
   -t, --threads THREADS                 Number of threads to do the calculations (default: 0)
   --num-frames NUM_FRAMES               Number of frames to analyze from the input files (default:
                                         all frames) (default: None)

--- a/src/ffmpeg_quality_metrics/__main__.py
+++ b/src/ffmpeg_quality_metrics/__main__.py
@@ -100,7 +100,12 @@ def main() -> None:
         "--dist-delay",
         type=float,
         default=0.0,
-        help="Delay the distorted video against the reference by this many seconds",
+        help=(
+            "Temporally align the inputs by trimming unmatched leading frames. "
+            "Positive means the distorted video starts later, so trim the "
+            "reference; negative means the distorted video starts earlier, so "
+            "trim the distorted input."
+        ),
     )
 
     ffmpeg_opts.add_argument(

--- a/src/ffmpeg_quality_metrics/ffmpeg_quality_metrics.py
+++ b/src/ffmpeg_quality_metrics/ffmpeg_quality_metrics.py
@@ -441,10 +441,17 @@ class FfmpegQualityMetrics:
             f"trim=start={abs(self.dist_delay)}," if self.dist_delay < 0 else ""
         )
 
+        # Align both streams before the reference is split between the scale
+        # filter and the metric filter. Feeding the untrimmed reference directly
+        # to scale while separately trimming it for the metric makes ffmpeg
+        # buffer the entire skipped lead-in on large positive delays. Real
+        # captures can start tens of seconds into a source, which previously
+        # grew memory into gigabytes and could be OOM-killed.
         filter_chains = [
-            f"[1][0]scale=rw:rh:flags={self.scaling_algorithm}[dist]",
-            f"[dist]{dist_trim}{select_filter}settb=AVTB,setpts=PTS-STARTPTS[distpts]",
-            f"[0]{ref_trim}{select_filter}settb=AVTB,setpts=PTS-STARTPTS[refpts]",
+            f"[0]{ref_trim}{select_filter}settb=AVTB,setpts=PTS-STARTPTS[refaligned]",
+            "[refaligned]split=2[refscale][refpts]",
+            f"[1]{dist_trim}{select_filter}settb=AVTB,setpts=PTS-STARTPTS[distaligned]",
+            f"[distaligned][refscale]scale=rw:rh:flags={self.scaling_algorithm}[distpts]",
         ]
 
         # generate split filters depending on the number of models
@@ -520,6 +527,16 @@ class FfmpegQualityMetrics:
             "log_fmt": "json",
             "n_threads": str(self.vmaf_options["n_threads"]),
             "n_subsample": str(self.vmaf_options["n_subsample"]),
+            # Terminate at the shorter of the two aligned streams. libvmaf is a
+            # framesync filter whose default (shortest=0, repeatlast=1) repeats
+            # the last frame of the shorter stream until the longer one ends.
+            # After dist_delay trims the leading frames to align the starts, the
+            # reference is typically still longer than the distorted clip (e.g. a
+            # full-length source vs a short recording); without shortest=1 those
+            # trailing reference frames are compared against a frozen distorted
+            # frame, cratering the pooled score. Compare only the overlap.
+            "shortest": "1",
+            "repeatlast": "0",
         }
 
         if self.vmaf_options["features"]:

--- a/src/ffmpeg_quality_metrics/ffmpeg_quality_metrics.py
+++ b/src/ffmpeg_quality_metrics/ffmpeg_quality_metrics.py
@@ -159,7 +159,7 @@ class FfmpegQualityMetrics:
             dist (str): distorted file
             scaling_algorithm (str, optional): A scaling algorithm. Must be one of the following: ["fast_bilinear", "bilinear", "bicubic", "experimental", "neighbor", "area", "bicublin", "gauss", "sinc", "lanczos", "spline"]. Defaults to "bicubic"
             framerate (float, optional): Force a frame rate. Defaults to None.
-            dist_delay (float): Delay the distorted file against the reference by this amount of seconds. Defaults to 0.
+            dist_delay (float): Temporally align the distorted file against the reference by this many seconds, by trimming the leading unmatched frames of one stream before comparison. A positive value means the distorted stream starts this many seconds after the reference (the reference's leading frames are trimmed); a negative value means the distorted stream leads (its leading frames are trimmed). Defaults to 0.
             dry_run (bool, optional): Don't run anything, just print commands. Defaults to False.
             verbose (bool, optional): Show more output. Defaults to False.
             threads (int, optional): Number of ffmpeg threads. Defaults to 0 (auto).
@@ -428,10 +428,23 @@ class FfmpegQualityMetrics:
         if self.num_frames is not None:
             select_filter = f"select='lt(n\\,{self.num_frames})',"
 
+        # Apply dist_delay by trimming the leading, unmatched portion of one
+        # stream so the two streams are temporally aligned before comparison.
+        # libvmaf (and the other metric filters) pair frames sequentially, so a
+        # PTS-only shift (e.g. -itsoffset) is cancelled by the setpts reset below
+        # and has no effect. Trimming happens at decode time - no re-encode.
+        # dist_delay > 0: distorted is delayed against the reference, so the
+        #   reference has extra leading frames -> trim the reference.
+        # dist_delay < 0: the distorted stream leads -> trim the distorted.
+        ref_trim = f"trim=start={self.dist_delay}," if self.dist_delay > 0 else ""
+        dist_trim = (
+            f"trim=start={abs(self.dist_delay)}," if self.dist_delay < 0 else ""
+        )
+
         filter_chains = [
             f"[1][0]scale=rw:rh:flags={self.scaling_algorithm}[dist]",
-            f"[dist]{select_filter}settb=AVTB,setpts=PTS-STARTPTS[distpts]",
-            f"[0]{select_filter}settb=AVTB,setpts=PTS-STARTPTS[refpts]",
+            f"[dist]{dist_trim}{select_filter}settb=AVTB,setpts=PTS-STARTPTS[distpts]",
+            f"[0]{ref_trim}{select_filter}settb=AVTB,setpts=PTS-STARTPTS[refpts]",
         ]
 
         # generate split filters depending on the number of models
@@ -688,7 +701,10 @@ class FfmpegQualityMetrics:
         if start_offset_timestamp is None:
             cmd.extend(["-r", str(ref_framerate)])
 
-        cmd.extend(["-i", self.ref, "-itsoffset", str(self.dist_delay)])
+        # Note: dist_delay is applied via a trim filter in the filter graph (see
+        # calculate), not via -itsoffset. A PTS shift here would be cancelled by
+        # the setpts=PTS-STARTPTS reset and would not align the streams.
+        cmd.extend(["-i", self.ref])
 
         # Add -ss before distorted input if start_offset is specified
         if start_offset_timestamp is not None:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -3,6 +3,7 @@
 import csv
 import json
 import os
+import subprocess
 from io import StringIO
 from typing import cast
 
@@ -280,3 +281,86 @@ class TestMetrics:
 
         # Should get only 1 frame
         assert len(f.data["psnr"]) == 1
+
+    def test_dist_delay_aligns_streams(self, misaligned_clips):
+        # The distorted clip is the reference content starting DELAY seconds in,
+        # re-encoded at a lower bitrate. Without alignment the frames are paired
+        # out of order and VMAF is low; with the correct dist_delay the streams
+        # are aligned by trimming the reference's leading frames and VMAF is high.
+        ref, dist, delay = misaligned_clips
+
+        unaligned_vmaf = ffqm(ref, dist, framerate=30, dist_delay=0)
+        unaligned_vmaf.calculate(metrics=["vmaf"])
+        aligned_vmaf = ffqm(ref, dist, framerate=30, dist_delay=delay)
+        aligned_vmaf.calculate(metrics=["vmaf"])
+
+        unaligned_score = unaligned_vmaf.get_global_stats()["vmaf"]["vmaf"][
+            "average"
+        ]
+        aligned_score = aligned_vmaf.get_global_stats()["vmaf"]["vmaf"]["average"]
+
+        # Alignment must raise VMAF substantially (regression guard: a broken
+        # dist_delay leaves the score unchanged).
+        assert aligned_score > unaligned_score + 20, (
+            f"dist_delay did not align streams: unaligned={unaligned_score:.2f}, "
+            f"aligned={aligned_score:.2f}"
+        )
+
+    def test_dist_delay_matches_manual_trim(self, misaligned_clips):
+        # A positive dist_delay must produce the same result as physically
+        # trimming the reference's leading frames by hand.
+        ref, dist, delay = misaligned_clips
+
+        via_param = ffqm(ref, dist, framerate=30, dist_delay=delay)
+        via_param.calculate(metrics=["vmaf"])
+        param_score = via_param.get_global_stats()["vmaf"]["vmaf"]["average"]
+
+        trimmed_ref = os.path.join(os.path.dirname(dist), "ref_trimmed.mp4")
+        subprocess.run(
+            [
+                "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
+                "-ss", str(delay), "-i", ref, "-c:v", "libx264", "-qp", "0",
+                "-pix_fmt", "yuv420p", trimmed_ref,
+            ],
+            check=True,
+        )
+        via_trim = ffqm(trimmed_ref, dist, framerate=30)
+        via_trim.calculate(metrics=["vmaf"])
+        trim_score = via_trim.get_global_stats()["vmaf"]["vmaf"]["average"]
+
+        assert via_param.dist_delay == delay
+        assert abs(param_score - trim_score) < 2.0, (
+            f"dist_delay result {param_score:.2f} differs from manual trim "
+            f"{trim_score:.2f}"
+        )
+
+
+@pytest.fixture(scope="module")
+def misaligned_clips(tmp_path_factory):
+    """
+    Build a reference clip and a 'distorted' clip that emulates a capture which
+    started `DELAY` seconds late: it is the reference content from `DELAY`
+    onwards, re-encoded at a lower bitrate. Yields (ref_path, dist_path, delay).
+    """
+    delay = 2.0
+    tmp = tmp_path_factory.mktemp("dist_delay")
+    ref = os.path.join(tmp, "ref.mp4")
+    dist = os.path.join(tmp, "dist.mp4")
+
+    subprocess.run(
+        [
+            "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
+            "-f", "lavfi", "-i", "testsrc2=size=1280x720:rate=30:duration=6",
+            "-c:v", "libx264", "-qp", "10", "-pix_fmt", "yuv420p", ref,
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
+            "-ss", str(delay), "-i", ref, "-t", "3",
+            "-c:v", "libx264", "-b:v", "1500k", "-pix_fmt", "yuv420p", dist,
+        ],
+        check=True,
+    )
+    return ref, dist, delay

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -299,6 +299,11 @@ class TestMetrics:
         ]
         aligned_score = aligned_vmaf.get_global_stats()["vmaf"]["vmaf"]["average"]
 
+        # The aligned reference still contains one second more content than the
+        # distorted clip. libvmaf must stop at the end of the shorter stream
+        # rather than repeat the distorted clip's final frame against that tail.
+        assert len(aligned_vmaf.data["vmaf"]) == 90
+
         # Alignment must raise VMAF substantially (regression guard: a broken
         # dist_delay leaves the score unchanged).
         assert aligned_score > unaligned_score + 20, (


### PR DESCRIPTION
## Summary

- Apply `dist_delay` by trimming the unmatched input lead-in inside the FFmpeg filtergraph.
- Align the streams before splitting the reference, avoiding large buffers for long positive delays.
- Stop libvmaf at the common aligned overlap instead of repeating the shorter stream's final frame.
- Clarify the CLI help and README documentation for positive and negative delays.
- Add regression tests for effective alignment, manual-trim equivalence, and overlap length.

## Problem

`dist_delay` previously shifted timestamps with `-itsoffset`, but the filtergraph subsequently reset both streams with `setpts=PTS-STARTPTS`. This cancelled the offset before frame comparison, so delayed inputs remained misaligned and produced misleading quality scores.

During a real recording analysis, an attempted filtergraph fix also exposed two related issues:

- Splitting an untrimmed reference before alignment buffered a 39.5-second lead-in and grew FFmpeg memory usage to approximately 6.4 GiB.
- libvmaf's default framesync behavior repeated the shorter recording's final frame against the remaining reference frames, incorrectly lowering the pooled VMAF score.

## Implementation

Positive delays now trim the reference lead-in, while negative delays trim the distorted lead-in. Both streams have their timestamps reset after trimming, and the aligned reference is split only afterward. libvmaf uses `shortest=1` and `repeatlast=0` so only the common aligned duration is scored.

The inputs are decoded and filtered without re-encoding.

## Validation

- Synthetic delayed clips verify that `dist_delay` improves VMAF by more than 20 points.
- Parameter-based alignment agrees with a physically trimmed reference within 2 VMAF points.
- A three-second distorted clip produces exactly 90 VMAF frame results at 30 fps, proving that the reference tail is excluded.
- A real 1920x1080, 30 fps recording aligned 39.5 seconds into its reference completed without the previous memory growth and scored mean VMAF `95.624`.

Targeted `tests/test_metrics.py` alignment regressions pass with FFmpeg 7.1.5 and libvmaf 3.2.0.